### PR TITLE
fixed plot_factors_violin, removing deprecated "s","size" parameters

### DIFF
--- a/mofax/plot_factors.py
+++ b/mofax/plot_factors.py
@@ -426,7 +426,6 @@ def plot_factors_violin(
     plot = partial(
         sns.violinplot,
         inner=None,
-        s=size,
     )
 
     g = _plot_grid(
@@ -439,7 +438,6 @@ def plot_factors_violin(
         zero_line_y=zero_line,
         linewidth=linewidth,
         zero_linewidth=zero_linewidth,
-        size=size,
         legend=legend,
         legend_prop=legend_prop,
         palette=palette,


### PR DESCRIPTION
Hi,

just noticed that the `mofa.plot_factors_violin` has a bug (might be relying on an older seaborn version) and plotting fails with a recent seaborn version (`seaborn==0.13.2`):

```python
import mofax as mfx
mfx.plot_factors_violin(model, factors=0, dots=True, violins=False)

> AttributeError: PolyCollection.set() got an unexpected keyword argument 's'
```

It traces back to

```
File python3.11/site-packages/mofax/plot_factors.py:432, in plot_factors_violin(model, factors, color, violins, dots, zero_line, group_label, groups, linewidth, zero_linewidth, size, legend, legend_prop, palette, alpha, violins_alpha, ncols, sharex, sharey, **kwargs)
    424     modifier = partial(modifier, data=z)
    426 plot = partial(
    427     sns.violinplot,
    428     inner=None,
    429     s=size,
    430 )
--> 432 g = _plot_grid(
    433     plot,
    434     z,
    435     x="factor",
    436     y="value",
    437     color=color,
    438     zero_line_x=False,
    439     zero_line_y=zero_line,
    440     linewidth=linewidth,
    441     zero_linewidth=zero_linewidth,
    442     size=size,
    443     legend=legend,
    444     legend_prop=legend_prop,
    445     palette=palette,
    446     ncols=ncols,
    447     sharex=sharex,
    448     sharey=sharey,
    449     modifier=modifier,
    450     **kwargs,
    451 )
```

Turns out ` sns.violinplot` doesn't accept `s` or `size` as an agument (any more?).
Removing those two lines (429 and 442) fixes the issue. Dotsize is still adjustable if desired:
```python
mfx.plot_factors_violin(model, factors=0, dots=True, violins=False, size=10)
```
